### PR TITLE
Fix the deprecated parameter of the model

### DIFF
--- a/object_detection.py
+++ b/object_detection.py
@@ -4,10 +4,10 @@ import cv2
 import time
 import csv
 from datetime import datetime
-from torchvision.models.detection import fasterrcnn_mobilenet_v3_large_320_fpn
+from torchvision.models.detection import fasterrcnn_mobilenet_v3_large_320_fpn, FasterRCNN_MobileNet_V3_Large_320_FPN_Weights
 
 # Load the pre-trained model
-model = fasterrcnn_mobilenet_v3_large_320_fpn(pretrained=True)
+model = fasterrcnn_mobilenet_v3_large_320_fpn(weights=FasterRCNN_MobileNet_V3_Large_320_FPN_Weights.COCO_V1)
 model.eval()
 
 # Load the labels used by the pre-trained model


### PR DESCRIPTION
Origin way to create a `fasterrcnn_mobilenet_v3_large_320_fpn` instance in the program is passing the parameter 'pretrained' as true. This, however, will cause warings for torchvision >= 0.13:

```
UserWarning: The parameter 'pretrained' is deprecated since 0.13 and may be removed in the future, please use 'weights' instead.
```

```
UserWarning: Arguments other than a weight enum or `None` for 'weights' are deprecated since 0.13 and may be removed in the future. The current behavior is equivalent to passing `weights=FasterRCNN_MobileNet_V3_Large_320_FPN_Weights.COCO_V1`. You can also use `weights=FasterRCNN_MobileNet_V3_Large_320_FPN_Weights.DEFAULT` to get the most up-to-date weights.
```

As a result, the parameter passed to the model is now changed to `weights=FasterRCNN_MobileNet_V3_Large_320_FPN_Weights.COCO_V1` to get rid of the warning without affecting the behavior.