### PR TITLE
Add the instruction about how to leave the program normally

### DIFF
--- a/object_detection.py
+++ b/object_detection.py
@@ -74,6 +74,7 @@ while True:
                     max_object_counts[label] = object_counts[label]
 
             # Show the image
+            cv2.putText(img, "Press q to leave the program", (10, 40), cv2.FONT_HERSHEY_SIMPLEX, 1, (0, 255, 255), 1, cv2.LINE_AA)
             cv2.imshow('Object Detection', img)
 
     if current_time - prev_time >= interval:


### PR DESCRIPTION
Users who don't know about how to leave the program will click the x to close the window infinitely.
An instruction telling them to press q is necessary.